### PR TITLE
Treat patches as binary files

### DIFF
--- a/splitpatch.rb
+++ b/splitpatch.rb
@@ -75,7 +75,7 @@ class Splitter
     def splitByFile
         legacy = false
         outfile = nil
-        stream = open(@filename)
+        stream = open(@filename, 'rb')
         until (stream.eof?)
             line = stream.readline
 
@@ -111,7 +111,7 @@ class Splitter
     def splitByHunk
         legacy = false
         outfile = nil
-        stream = open(@filename)
+        stream = open(@filename, 'rb')
         filename = ""
         counter = 0
         header = ""


### PR DESCRIPTION
In Ruby 1.9.x and 2.x, the strings returned by `IO#readfile` are marked as
encoded in UTF8 (or other encodings, depending on the runtime environment).

However, not all patches are correctly encoded. Parsing the patch
produced by this script (a reduction of a real test case)

    ( echo "--- a"; echo "--- b" ; \
      echo "@@ -1673,8 + 1672,7 @@ Section" ; \
      echo " foo" ; echo ; echo "-blabla" ; \
      echo "-Moss" ; echo -e "+M\xf6ss" ; \
      echo ; echo " quux") > moss.patch

will generate this error

    $ ./splitpatch.rb /tmp/moss.patch
    ./splitpatch.rb:83:in `splitByFile': invalid byte sequence in UTF-8 (ArgumentError)
	from ./splitpatch.rb:224:in `<main>'

This patch fixes the problem by opening the files in binary mode. In
binary mode, the strings returned by `IO#readfile` are treated as
encodingless 8-bit data.