### PR TITLE
Make the build reproducible

### DIFF
--- a/man/pod2man.mk
+++ b/man/pod2man.mk
@@ -39,9 +39,9 @@ MANSECT		?= 1
 
 DATE_FMT = %Y-%m-%d
 ifdef SOURCE_DATE_EPOCH
-PODCENTER	?= $$(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u "+$(DATE_FMT)")
+PODCENTER	?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u "+$(DATE_FMT)")
 else
-PODCENTER	?= $$(date "$(DATE_FMT)")
+PODCENTER	?= $(date "$(DATE_FMT)")
 endif
 
 # Directories


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that `splitpatch` could not be built reproducibly. This is due to my previous patch used `$$(shell …)` instead of `$(shell …)` (note the change of number of dollar signs...) so that we were still embedding today's date into the pod2man `--center` argument.

This was originally filed in Debian as [#944131](https://bugs.debian.org/944131)