### PR TITLE
Fix PODCENTER evaluation in else clause

### DIFF
--- a/man/pod2man.mk
+++ b/man/pod2man.mk
@@ -41,7 +41,7 @@ DATE_FMT = %Y-%m-%d
 ifdef SOURCE_DATE_EPOCH
 PODCENTER	?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u "+$(DATE_FMT)")
 else
-PODCENTER	?= $(date "$(DATE_FMT)")
+PODCENTER	?= $(shell date "+$(DATE_FMT)")
 endif
 
 # Directories


### PR DESCRIPTION
Fix minor syntax error in `else` clause by using `shell` operator and adding `+` to date format specification. Without this `PODCENTER` is empty and causes `podchecker` to fail with:

```sh
Option center requires an argument
```