### PR TITLE
Fix getFilename crashing 

### DIFF
--- a/splitpatch.rb
+++ b/splitpatch.rb
@@ -80,7 +80,8 @@ class Splitter
         tokens = tokens[0].split("/")
 
         if @fullname
-            return tokens.reject!(&:empty?).join('-')
+            tokens.reject!(&:empty?)
+            return tokens.join('-')
         else
             return tokens[-1]
         end

--- a/splitpatch.rb
+++ b/splitpatch.rb
@@ -194,7 +194,7 @@ OPTIONS
         Read file and save patch hunks using ENCODING. Default is 'UTF-8'.
 
     -f, --fullname
-        Use full name upn saving patch hunks
+        Use full name upon saving patch hunks
 
     -h, --help
         Show short help. This page.


### PR DESCRIPTION
Hi and thanks for maintaining this awesome tool that I recently discovered. I had trouble using the `-f` (fullname) option because it would almost always crash with the following message:
```ruby
Traceback (most recent call last):
	4: from ../splitpatch/splitpatch.rb:299:in `<main>'
	3: from ../splitpatch/splitpatch.rb:295:in `main'
	2: from ../splitpatch/splitpatch.rb:126:in `splitByFile'
	1: from ../splitpatch/splitpatch.rb:68:in `getFilenameByHeader'
../splitpatch/splitpatch.rb:89:in `getFilename': undefined method `join' for nil:NilClass (NoMethodError)
```
Without any prior experience in Ruby, I found that the `reject!()` method returns `nil` if no changes are made to the array, so `join()` keeps crashing with the above error. I just  split the return line into two, to ignore the returning value and just modify the array in place.

I have not tested it thoroughly and as I said, I am not a Ruby developer so if I made any mistake, please correct me kindly :)

Also, fixed a typo in the help message.