### PR TITLE
Add uninstall rule in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ INSTALL_BIN	= $(INSTALL) -m 755
 INSTALL_DATA	= $(INSTALL) -m 644
 INSTALL_SUID	= $(INSTALL) -m 4755
 
+RM			= rm -f
+
 SRCS		= $(PACKAGE).rb
 
 all: doc
@@ -78,7 +80,11 @@ install-bin:
 
 install: install-bin install-man
 
+uninstall:
+	$(RM) $(BINDIR)/$(PACKAGE)
+	$(RM) $(MANDIR1)/$(PACKAGE).1
+
 .PHONY: all doc
-.PHONY: clean distclean realclean install install-bin install-man
+.PHONY: clean distclean realclean install install-bin install-man uninstall
 
 # End of file


### PR DESCRIPTION
Hi, this is an old improvement that was made almost 2 years ago, but I never submitted a pull request for it. Now that I did some cleanup in my repos, I noticed it and thought that might be useful to include it in the upstream repo.

Basically, it adds an uninstall rule in the Makefile, so the installed binary and man page can be removed from the system.