### PR TITLE
Ensure compatibility by replacing --mode with -m in install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,9 @@ MANDIR		= $(DESTDIR)$(mandir)
 MANDIR1		= $(MANDIR)/man1
 
 INSTALL		= /usr/bin/install
-INSTALL_BIN	= $(INSTALL) --mode=755
-INSTALL_DATA	= $(INSTALL) --mode=644
-INSTALL_SUID	= $(INSTALL) --mode=4755
+INSTALL_BIN	= $(INSTALL) -m 755
+INSTALL_DATA	= $(INSTALL) -m 644
+INSTALL_SUID	= $(INSTALL) -m 4755
 
 RM		= rm --force
 LN		= ln --symbolic --relative


### PR DESCRIPTION
The install command on Linux supports the `--mode=` option for setting file permissions. However, FreeBSD's `install` command does not recognize `--mode=` and instead only supports the `-m` flag for specifying file modes.

This patch replaces `--mode=` with `-m` to ensure compatibility across both Linux and FreeBSD. Since both platforms support `-m`, this change maintains functionality while improving portability.

Changes:

*   Replace `--mode=` with `-m` in install command.
*   Ensure the change does not affect existing behavior on Linux.

Impact:

*   Fixes compatibility issues on FreeBSD.
*   No change in behavior on Linux.